### PR TITLE
symfony 5 version return 0

### DIFF
--- a/src/Command/SchemaLoadCommand.php
+++ b/src/Command/SchemaLoadCommand.php
@@ -103,7 +103,7 @@ class SchemaLoadCommand extends Command
 
         if (!count($queries)) {
             $output->writeln("<info>No schema changes required</info>");
-            return;
+            return 0;
         }
 
         if ($apply) {
@@ -123,5 +123,6 @@ class SchemaLoadCommand extends Command
                 $output->writeln($query);
             }
         }
+         return 0;
     }
 }


### PR DESCRIPTION
https://symfony.com/doc/current/console.html#creating-a-command
must be of the type int, NULL returned. in vendor/symfony/console/Command/Command.php:258
https://github.com/symfony/symfony/blob/5.0/src/Symfony/Component/Console/Command/Command.php#L159